### PR TITLE
Add User Profile button to comparison

### DIFF
--- a/src/main/kotlin/me/vkryl/td/TdEquals.kt
+++ b/src/main/kotlin/me/vkryl/td/TdEquals.kt
@@ -429,6 +429,10 @@ fun InlineKeyboardButtonType.equalsTo(b: InlineKeyboardButtonType): Boolean {
         require(this is InlineKeyboardButtonTypeSwitchInline && b is InlineKeyboardButtonTypeSwitchInline)
         this.inCurrentChat == b.inCurrentChat && this.query == b.query
       }
+      InlineKeyboardButtonTypeUser.CONSTRUCTOR -> {
+        require(this is InlineKeyboardButtonTypeUser && b is InlineKeyboardButtonTypeUser)
+        this.userId == b.userId
+      }
       InlineKeyboardButtonTypeCallbackGame.CONSTRUCTOR,
       InlineKeyboardButtonTypeBuy.CONSTRUCTOR -> true
       else -> error(this.toString())


### PR DESCRIPTION
Telegram X usually crashes on clicking a Inline Result having a User Profile button attached.
Tracing it, redirected me here.

https://t.me/tgandroidtests/216251

After making the change, I did'nt observe any immediate crash.

Error Trace (for descriptive report):
```
=== Stack Trace Dump ===

java.lang.IllegalStateException: InlineKeyboardButtonTypeUser {
  userId = ....
}
	at me.vkryl.td.Td__TdEqualsKt.equalsTo(TdEquals.kt:434)
	at me.vkryl.td.Td.equalsTo(Unknown Source:1)
	at me.vkryl.td.Td__TdEqualsKt.equalsTo(TdEquals.kt:404)
	at me.vkryl.td.Td.equalsTo(Unknown Source:1)
	at me.vkryl.td.Td__TdEqualsKt.equalsTo(TdEquals.kt:510)
	at me.vkryl.td.Td.equalsTo(Unknown Source:1)
	at org.thunderdog.challegram.data.TGMessage.setSendSucceeded(TGMessage.java:4965)
```